### PR TITLE
Add venv directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ node_modules/
 npm-debug.log
 yarn-debug.log
 yarn-error.log
-
+venv/
     


### PR DESCRIPTION
The venv directory gets created by the run_tests.sh script when creating
a virutal environment for them. Adding it to the git ignore